### PR TITLE
Avoid uncaught exceptions in certain edge cases in Autoloader

### DIFF
--- a/classes/Autoloader.php
+++ b/classes/Autoloader.php
@@ -117,10 +117,14 @@ class AC_Autoloader {
 
 				$class_name = $prefix . str_replace( '.php', '', $leaf->getFilename() );
 
-				$r = new ReflectionClass( $class_name );
+				try {
+					$r = new ReflectionClass( $class_name );
 
-				if ( $r->isInstantiable() ) {
-					$class_names[] = $class_name;
+					if ( $r->isInstantiable() ) {
+						$class_names[] = $class_name;
+					}
+				} catch( ReflectionException $e ) {
+					// Class doesn't exist or couldn't be loaded
 				}
 			}
 		}


### PR DESCRIPTION
Just ran into this issue on a site, for some reason the class couldn't be found and would not load. It was a site being upgraded from an older version of AC. Maybe logging an error to the error log or something might be good here?