### PR TITLE
ajax callback to manual

### DIFF
--- a/classes/Helper/Html.php
+++ b/classes/Helper/Html.php
@@ -129,13 +129,9 @@ class AC_Helper_Html {
 	 * @param string $label
 	 * @param string $column_name
 	 *
-	 * @return string|false HTML
+	 * @return string
 	 */
-	public function toggle_box_ajax( $id, $label, $column_name ) {
-		if ( ! $label ) {
-			return false;
-		}
-
+	public function get_ajax_toggle_box_link( $id, $label, $column_name ) {
 		return ac_helper()->html->link( '#', $label . '<div class="spinner"></div>', array(
 			'class'              => 'ac-toggle-box-link',
 			'data-column'        => $column_name,
@@ -404,7 +400,7 @@ class AC_Helper_Html {
 
 	/**
 	 * @param string $value HTML
-	 * @param int $removed
+	 * @param int    $removed
 	 *
 	 * @return string
 	 */

--- a/classes/ListScreen.php
+++ b/classes/ListScreen.php
@@ -814,11 +814,6 @@ abstract class AC_ListScreen {
 		 */
 		$value = apply_filters( 'ac/column/value', $value, $id, $column );
 
-		// Display a toggle box with an ajax callback.
-		if ( $column instanceof AC_Column_AjaxValue && $value !== $column->get_empty_char() ) {
-			$value = ac_helper()->html->toggle_box_ajax( $id, $value, $column->get_name() );
-		}
-
 		return $value;
 	}
 


### PR DESCRIPTION
Make the AJAX callback a manual action and skip the empty label check
(that’s your responsibility)

fixes https://github.com/codepress/admin-columns-issues/issues/908